### PR TITLE
Remove link to tweet that doesn't exist any more

### DIFF
--- a/tabs/about.md
+++ b/tabs/about.md
@@ -4,7 +4,7 @@ title: About
 
 [![Image of Peter Steinberger speaking at a conference](/assets/img/steipete-about.jpg){:height="100%" width="100%"}](https://github.com/steipete/speaking/blob/master/README.md)
 
-Follow what I’m up to on [Twitter](https://twitter.com/steipete), [GitHub](https://github.com/steipete), and [Instagram](https://www.instagram.com/sportg33k). A word of warning: I seem to [complain a lot](https://twitter.com/maccatalan/status/1319179176042287104?s=21). 😅
+Follow what I’m up to on [Twitter](https://twitter.com/steipete), [GitHub](https://github.com/steipete), and [Instagram](https://www.instagram.com/sportg33k).
 
 ### PSPDFKit
 


### PR DESCRIPTION
Introduced with https://github.com/steipete/steipete.com/commit/bc71d53bf3768176bf9797defbef72f8ccaf107f